### PR TITLE
Add symlink on post install for ts declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export * from './platform-types'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "build": "node ./build.js",
     "generate": "node --experimental-modules ./generator/index.mjs",
     "release": "node ./make-release.js",
-    "all": "npm run generate --docs & npm run build & npm run release"
+    "all": "npm run generate --docs & npm run build & npm run release",
+    "postinstall": "node postInstall.js"
   },
   "devDependencies": {
     "bindings": "^1.5.0",

--- a/postInstall.js
+++ b/postInstall.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const vkversion = '1.1.126';
+
+try {
+  fs.unlinkSync('./platform-types');
+} catch (e) { }
+try {
+  fs.symlinkSync(`./generated/${vkversion}/${process.platform}/`, './platform-types', 'junction');
+} catch (e) { }


### PR DESCRIPTION
This was added before to solve #36
But for some reason removed afterwards
Now also supports windows without requiring admin rights